### PR TITLE
The elisp function names of upstream have changed.

### DIFF
--- a/keybindings.el
+++ b/keybindings.el
@@ -4,8 +4,8 @@
 ;; The remaining useful keybindings to using Leetcode
 (spacemacs/set-leader-keys
   "a L l" 'leetcode
-  "a L d" 'leetcode-show-descri
-  "a L r" 'leetcode--problems-refresh
+  "a L d" 'leetcode-show-description
+  "a L r" 'leetcode-problems-refresh
   "a L t" 'leetcode-try
   "a L u" 'leetcode-submit
   )

--- a/packages.el
+++ b/packages.el
@@ -31,6 +31,6 @@
     (setq
      leetcode-account "<username>"
      leetcode-password "<password-here>")
-    (define-key leetcode--problems-mode-map (kbd "TAB") 'leetcode-show-descri)
-    (define-key leetcode--problems-mode-map (kbd "<return>") 'leetcode-show-descri)
+    (define-key leetcode--problems-mode-map (kbd "TAB") 'leetcode-show-description)
+    (define-key leetcode--problems-mode-map (kbd "<return>") 'leetcode-show-description)
     ))


### PR DESCRIPTION
The following functions are no longer there:
- `leetcode-show-descri`
- `leetcode--problems-refresh`.

Changed them here to keep them in sync with upstream.